### PR TITLE
Compatibility: Update to the latest asset classification client version

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,7 +8,7 @@ object Versions {
     const val ProvenanceProtobuf = "1.8.0"
     const val ProvenanceClient = "1.0.5"
     const val ProvenanceHdWallet = "0.1.15"
-    const val ProvenanceAssetClassification = "1.0.2"
+    const val ProvenanceAssetClassification = "1.1.3"
     const val AssetModel = "0.1.2"
     const val P8eScope = "0.1.0"
     // const val Detekt = "1.17.0"


### PR DESCRIPTION
# Description
The asset classification smart contract was recently upgraded to `v1.0.3`, which brings a change to its `AssetDefinition` data type that lacks backward compatibility with its client library.  The client library's version `v1.1.3` brings compatibility with this change, which is required after the contract is migrated to `v1.0.3` in testnet.  This PR will be merged shortly after the migration occurs, ensuring the maximum compatibility window.  This is a fairly safe merge to make for this service, because the code is only used when an asset type is provided to the onboarding route, which is not commonplace in any widely-used applications at the moment.

# Linked PRs
* Asset Classification Contract Upgrade: https://github.com/provenance-io/asset-classification-smart-contract/pull/48
* Asset Classification Libs Upgrade: https://github.com/provenance-io/asset-classification-libs/pull/21