### PR TITLE
Add a global CORS filter + config

### DIFF
--- a/service/src/main/kotlin/io/provenance/asset/config/Properties.kt
+++ b/service/src/main/kotlin/io/provenance/asset/config/Properties.kt
@@ -69,3 +69,12 @@ class ServiceKeysProperties : LoggableProperties() {
     lateinit var assetManager: String
 
 }
+
+@ConfigurationProperties(prefix = "cors")
+class CorsProperties : LoggableProperties() {
+
+    var allowedOrigins: List<String> = emptyList()
+    var allowedHeaders: List<String> = emptyList()
+    var allowedMethods: List<String> = emptyList()
+
+}

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -26,3 +26,9 @@ spring.devtools.livereload.enabled=false
 spring.main.allow-bean-definition-overriding=true
 
 spring.profiles.active=development
+
+# CORS
+cors.allowed-origins[0]=*
+cors.allowed-headers[0]=x-address
+cors.allowed-headers[1]=x-public-key
+cors.allowed-methods[0]=*


### PR DESCRIPTION
Production is failing due to CORS preflight rejection of x-address and x-public-key headers. Let's be more explicit and use a config driven approach to our CORS filter.